### PR TITLE
Adapta la experiencia mobile-first en la vista de cursos

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,9 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  min-height: 100vh;
+  display: flex;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+main {
+  flex: 1;
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,9 +4,9 @@ import Header from "./Header";
 
 const Layout = () => {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="flex min-h-screen w-full flex-col bg-background text-foreground">
       <Header />
-      <main className="pb-20 md:pb-8">
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 pb-24 pt-4 sm:px-6 md:pb-12 md:pt-6">
         <Outlet />
       </main>
       <BottomNavigation />

--- a/src/index.css
+++ b/src/index.css
@@ -97,7 +97,12 @@
     @apply border-border;
   }
 
+  html {
+    height: 100%;
+  }
+
   body {
-    @apply bg-background text-foreground;
+    min-height: 100%;
+    @apply bg-background text-foreground antialiased;
   }
 }


### PR DESCRIPTION
## Resumen
- actualicé los estilos globales para que el layout parta de mobile-first y ocupe todo el ancho disponible
- ajusté el layout principal para centrar el contenido y dar espaciado responsive
- rediseñé por completo la pantalla de curso con un hero informativo, navegación móvil y módulos en acordeón

## Testing
- ❌ `CI=1 npm run build` *(falla porque falta la dependencia `axios` requerida por authService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dae8a2f4448330ab15d56d02e3030d