### PR TITLE
Rediseñar detalle de curso para mobile first

### DIFF
--- a/src/pages/Curso.tsx
+++ b/src/pages/Curso.tsx
@@ -1,528 +1,331 @@
-import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Progress } from "@/components/ui/progress";
+import React, { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-
 import {
   ArrowLeft,
-  Trophy,
-  Play,
-  FileText,
-  Download,
-  CheckCircle2,
-  Clock,
-  HelpCircle,
-  FileImage,
   BookOpen,
-  GraduationCap,
+  FileText,
+  Play,
+  School,
   Video,
-  Home,
 } from "lucide-react";
 
-const ModuleView = () => {
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const courseDetail = {
+  id: "fitness-grupal",
+  title: "Instructorado de fitness grupal",
+  summary:
+    "Formación completa en fitness grupal con metodología actualizada y base científica aplicada.",
+  subjects: [
+    {
+      id: "fundamentos",
+      name: "Fundamentos Anatómicos",
+      description:
+        "Comprendé cómo funciona el cuerpo y cómo impacta en la actividad física.",
+      modules: [
+        {
+          id: "fundamentos-anatomia",
+          name: "Anatomía y Fisiología",
+          description: "Base estructural del movimiento humano.",
+          items: [
+            {
+              id: "video-esqueleto",
+              title: "Anatomía del esqueleto humano",
+              description:
+                "Recorrido visual por las principales estructuras óseas.",
+              type: "VIDEO" as const,
+              duration: "18 min",
+            },
+            {
+              id: "pdf-articulaciones",
+              title: "Guía de articulaciones",
+              description: "Clasificación y cuidados básicos.",
+              type: "PDF" as const,
+              size: "2.5 MB",
+            },
+            {
+              id: "video-musculos",
+              title: "Músculos en acción",
+              description: "Principales grupos musculares y funciones.",
+              type: "VIDEO" as const,
+              duration: "22 min",
+            },
+          ],
+        },
+        {
+          id: "fundamentos-sistemas",
+          name: "Sistemas Energéticos",
+          description: "Cómo el cuerpo obtiene y usa la energía.",
+          items: [
+            {
+              id: "video-sistemas",
+              title: "Introducción a los sistemas energéticos",
+              description: "Fases y características clave.",
+              type: "VIDEO" as const,
+              duration: "15 min",
+            },
+            {
+              id: "pdf-mapas",
+              title: "Mapas metabólicos",
+              description: "Material de apoyo descargable.",
+              type: "PDF" as const,
+              size: "1.8 MB",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "planificacion",
+      name: "Planificación y Metodología",
+      description:
+        "Herramientas prácticas para diseñar clases seguras y dinámicas.",
+      modules: [
+        {
+          id: "planificacion-bases",
+          name: "Principios del Entrenamiento",
+          description: "Planificá sesiones con foco en resultados.",
+          items: [
+            {
+              id: "video-principios",
+              title: "Variables clave del entrenamiento",
+              description: "Frecuencia, intensidad y volumen explicados.",
+              type: "VIDEO" as const,
+              duration: "20 min",
+            },
+            {
+              id: "pdf-hojas",
+              title: "Plantillas de planificación",
+              description: "Descargá y adaptá a tus clases.",
+              type: "PDF" as const,
+              size: "800 KB",
+            },
+          ],
+        },
+        {
+          id: "planificacion-seguridad",
+          name: "Seguridad y Adaptaciones",
+          description: "Cuidados esenciales para distintos perfiles.",
+          items: [
+            {
+              id: "video-seguridad",
+              title: "Chequeos previos y adaptaciones",
+              description: "Checklist previo a cada clase.",
+              type: "VIDEO" as const,
+              duration: "12 min",
+            },
+            {
+              id: "pdf-checklist",
+              title: "Checklist descargable",
+              description: "Formato imprimible para llevar a clase.",
+              type: "PDF" as const,
+              size: "600 KB",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+type ModuleItem = (typeof courseDetail.subjects)[number]["modules"][number]["items"][number];
+
+type Subject = (typeof courseDetail.subjects)[number];
+
+type Module = Subject["modules"][number];
+
+const CourseDetailPage: React.FC = () => {
   const navigate = useNavigate();
+  const [selectedSubjectId, setSelectedSubjectId] = useState(courseDetail.subjects[0]?.id);
+  const [expandedModuleId, setExpandedModuleId] = useState<string | null>(null);
 
-  // Estructura de datos como en tu implementación real
-  const courseData = {
-    id: "fitness-grupal",
-    title: "Instructorado de fitness grupal",
-    description:
-      "Formación completa en fitness grupal con metodología actualizada y base científica aplicada.",
-    image:
-      "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=600&h=300&fit=crop",
-    level: "Intermedio",
-    modules: [
-      {
-        id: "modulo-1",
-        title: "Anatomía y Fisiología",
-        description: "Fundamentos del cuerpo humano y su funcionamiento",
-        contents: [
-          {
-            id: "content-1",
-            title: "Anatomía del esqueleto humano",
-            description:
-              "Introducción clara al esqueleto humano, clasificación y funciones de los huesos",
-            type: "VIDEO",
-            url: "https://example.com/video1",
-            thumbnail:
-              "https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=300&h=200&fit=crop",
-            duration: "70 min",
-            order: 1,
-            completed: true,
-          },
-          {
-            id: "content-2",
-            title: "Aparato locomotor",
-            description: "Material teórico complementario",
-            type: "PDF",
-            url: "https://example.com/pdf1",
-            order: 2,
-            completed: true,
-          },
-          {
-            id: "content-3",
-            title: "Articulaciones",
-            description:
-              "Tipos de articulaciones y su función en el movimiento",
-            type: "VIDEO",
-            url: "https://example.com/video2",
-            thumbnail:
-              "https://images.unsplash.com/photo-1576091160399-112ba8d25d1f?w=300&h=200&fit=crop",
-            duration: "60 min",
-            order: 3,
-            completed: false,
-          },
-        ],
-      },
-      {
-        id: "modulo-2",
-        title: "Metodología del Entrenamiento",
-        description: "Fundamentos científicos del entrenamiento deportivo",
-        contents: [
-          {
-            id: "content-4",
-            title: "Principios del Entrenamiento",
-            description: "Fundamentos científicos del entrenamiento deportivo",
-            type: "VIDEO",
-            url: "https://example.com/video3",
-            duration: "50 min",
-            order: 1,
-            completed: false,
-          },
-          {
-            id: "content-5",
-            title: "Evaluación Diagnóstica",
-            description: "Test de conocimientos iniciales",
-            type: "EVALUATION",
-            url: "https://example.com/test1",
-            order: 2,
-            completed: false,
-          },
-        ],
-      },
-    ],
+  const selectedSubject = useMemo<Subject | undefined>(() => {
+    return courseDetail.subjects.find((subject) => subject.id === selectedSubjectId);
+  }, [selectedSubjectId]);
+
+  const handleModuleToggle = (moduleId: string) => {
+    setExpandedModuleId((current) => (current === moduleId ? null : moduleId));
   };
 
-  // Estados
-  const [activeTab, setActiveTab] = useState("overview");
-
-  // Calcular progreso total
-  const getInitialCompletedContents = () => {
-    const completed = [];
-    courseData.modules.forEach((module) => {
-      module.contents.forEach((content) => {
-        if (content.completed) {
-          completed.push(content.id);
-        }
-      });
-    });
-    return completed;
-  };
-
-  const [completedContents, setCompletedContents] = useState(
-    getInitialCompletedContents()
-  );
-
-  const totalContents = courseData.modules.reduce(
-    (acc, module) => acc + module.contents.length,
-    0
-  );
-  const completedCount = completedContents.length;
-  const progressPercentage =
-    totalContents > 0 ? Math.round((completedCount / totalContents) * 100) : 0;
-
-  // Helper functions
-  const toggleContentComplete = (contentId) => {
-    setCompletedContents((prev) =>
-      prev.includes(contentId)
-        ? prev.filter((id) => id !== contentId)
-        : [...prev, contentId]
-    );
-  };
-
-  const handleContentClick = (content) => {
-    if (content.type === "VIDEO") {
-      console.log("Opening video:", content.title);
-    } else {
-      window.open(content.url, "_blank");
+  const getItemIcon = (type: ModuleItem["type"]) => {
+    if (type === "VIDEO") {
+      return <Play className="h-4 w-4" />;
     }
+
+    return <FileText className="h-4 w-4" />;
   };
 
-  const getIcon = (type) => {
-    switch (type) {
-      case "VIDEO":
-        return <Play className="w-4 h-4" />;
-      case "PDF":
-        return <FileText className="w-4 h-4" />;
-      case "EVALUATION":
-        return <HelpCircle className="w-4 h-4" />;
-      case "IMAGE":
-        return <FileImage className="w-4 h-4" />;
-      default:
-        return <FileText className="w-4 h-4" />;
+  const getItemBadge = (item: ModuleItem) => {
+    if (item.type === "VIDEO") {
+      return item.duration;
     }
+
+    return item.size;
   };
 
-  const getTypeColor = (type) => {
-    return "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300";
-  };
+  const renderModule = (module: Module) => {
+    const isExpanded = expandedModuleId === module.id;
 
-  const getAllContents = () => {
-    return courseData.modules.flatMap((module) =>
-      module.contents.map((content) => ({
-        ...content,
-        moduleName: module.title,
-      }))
-    );
-  };
-
-  const renderContentItem = (content, showModule = false) => (
-    <Card
-      key={content.id}
-      className="hover:shadow-sm transition-all duration-200 border-gray-100 dark:border-gray-800 cursor-pointer"
-      onClick={() => handleContentClick(content)}
-    >
-      <CardContent className="p-4">
-        <div className="flex items-center gap-4">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              toggleContentComplete(content.id);
-            }}
-            className={`w-5 h-5 rounded-full flex items-center justify-center border-2 transition-colors flex-shrink-0 ${
-              completedContents.includes(content.id)
-                ? "bg-orange-500 border-orange-500 text-white"
-                : "border-gray-300 hover:border-orange-400"
-            }`}
-          >
-            {completedContents.includes(content.id) && (
-              <CheckCircle2 className="w-3 h-3" />
-            )}
-          </button>
-
-          {content.thumbnail && content.type === "VIDEO" ? (
-            <div className="relative flex-shrink-0">
-              <img
-                src={content.thumbnail}
-                alt={content.title}
-                className="w-14 h-10 object-cover rounded-md"
-              />
-              <div className="absolute inset-0 bg-black/30 rounded-md flex items-center justify-center">
-                <Play className="w-3 h-3 text-white" />
-              </div>
+    return (
+      <Card key={module.id} className="border-slate-200 shadow-none">
+        <button
+          type="button"
+          onClick={() => handleModuleToggle(module.id)}
+          className="w-full text-left"
+        >
+          <CardHeader className="space-y-1 px-4 py-3 sm:py-4">
+            <CardTitle className="text-base font-semibold text-slate-900">
+              {module.name}
+            </CardTitle>
+            <p className="text-sm text-slate-500">{module.description}</p>
+            <div className="flex items-center gap-2 text-xs text-slate-400">
+              <Video className="h-3.5 w-3.5" />
+              <span>
+                {module.items.filter((item) => item.type === "VIDEO").length} videos
+              </span>
+              <span aria-hidden="true">•</span>
+              <FileText className="h-3.5 w-3.5" />
+              <span>
+                {module.items.filter((item) => item.type === "PDF").length} PDF
+              </span>
             </div>
-          ) : (
-            <div
-              className={`w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 ${getTypeColor(
-                content.type
-              )}`}
-            >
-              {getIcon(content.type)}
-            </div>
-          )}
+          </CardHeader>
+        </button>
 
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h4 className="font-medium text-gray-900 dark:text-gray-100 truncate">
-                {content.title}
-              </h4>
-              <Badge
-                variant="outline"
-                className="text-xs border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400"
+        {isExpanded && (
+          <CardContent className="space-y-3 border-t border-slate-100 bg-white px-4 py-3">
+            {module.items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-start gap-3 rounded-lg border border-slate-100 bg-slate-50/70 px-3 py-3"
               >
-                {content.type}
-              </Badge>
-            </div>
-            <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-1 mb-2">
-              {content.description}
-            </p>
-            <div className="flex items-center gap-3 text-xs text-gray-400">
-              {showModule && (
-                <span className="px-2 py-1 bg-gray-50 dark:bg-gray-800 rounded text-xs">
-                  {content.moduleName}
+                <span
+                  className={`mt-1 flex h-9 w-9 items-center justify-center rounded-full ${
+                    item.type === "VIDEO"
+                      ? "bg-orange-100 text-orange-600"
+                      : "bg-slate-200 text-slate-600"
+                  }`}
+                  aria-hidden="true"
+                >
+                  {getItemIcon(item.type)}
                 </span>
-              )}
-              {content.duration && (
-                <div className="flex items-center gap-1">
-                  <Clock className="w-3 h-3" />
-                  <span>{content.duration}</span>
+                <div className="flex-1 space-y-1">
+                  <p className="text-sm font-medium text-slate-900">{item.title}</p>
+                  <p className="text-xs text-slate-500">{item.description}</p>
+                  <div className="flex items-center gap-2">
+                    <Badge
+                      variant="outline"
+                      className={`border-0 text-[11px] font-medium uppercase tracking-wide ${
+                        item.type === "VIDEO"
+                          ? "bg-orange-500/10 text-orange-600"
+                          : "bg-slate-500/10 text-slate-600"
+                      }`}
+                    >
+                      {item.type}
+                    </Badge>
+                    <span className="text-xs text-slate-400">{getItemBadge(item)}</span>
+                  </div>
                 </div>
-              )}
-            </div>
-          </div>
-
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleContentClick(content);
-            }}
-            className="text-gray-600 hover:text-orange-600"
-          >
-            {content.type === "VIDEO" ? (
-              <Play className="w-4 h-4" />
-            ) : (
-              <Download className="w-4 h-4" />
-            )}
-          </Button>
-        </div>
-      </CardContent>
-    </Card>
-  );
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-auto px-2 text-xs text-orange-600"
+                >
+                  {item.type === "VIDEO" ? "Ver" : "Descargar"}
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        )}
+      </Card>
+    );
+  };
 
   return (
-    <div className="container mx-auto px-4 py-6 space-y-6 pb-24">
-      {/* Header minimalista */}
-      <div className="flex items-center gap-4">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => navigate("/")}
-          className="hover:bg-gray-100 dark:hover:bg-gray-800"
-        >
-          <ArrowLeft className="w-5 h-5" />
-        </Button>
-        <div className="flex-1 min-w-0">
-          <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100 truncate">
-            {courseData.title}
-          </h1>
-          {/* Descripción solo visible en desktop */}
-          <p className="text-gray-500 dark:text-gray-400 mt-1 hidden sm:block line-clamp-1">
-            {courseData.description}
-          </p>
-        </div>
-      </div>
-
-      {/* Progress Card simplificada */}
-      <Card className="border-gray-100 dark:border-gray-800">
-        <CardContent className="p-4">
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100">
-                Progreso del Curso
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {completedCount} de {totalContents} elementos
-              </p>
-            </div>
-            <div className="text-center">
-              <div className="text-2xl font-bold text-orange-500">
-                {progressPercentage}%
-              </div>
-              <Trophy className="w-6 h-6 mx-auto mt-1 text-orange-500" />
-            </div>
-          </div>
-          <div className="h-2 w-full bg-gray-100 dark:bg-gray-700 rounded-full">
-            <div
-              className="h-2 bg-gradient-to-r from-orange-400 to-orange-500 rounded-full transition-all duration-300 shadow-sm"
-              style={{ width: `${progressPercentage}%` }}
-            ></div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Desktop Tabs - más minimalistas */}
-      <div className="hidden sm:block">
-        <div className="flex border-b border-gray-100 dark:border-gray-800">
-          <button
-            onClick={() => setActiveTab("overview")}
-            className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === "overview"
-                ? "border-orange-500 text-orange-600"
-                : "border-transparent text-gray-500 hover:text-gray-700"
-            }`}
+    <div className="min-h-screen bg-white">
+      <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/90 backdrop-blur">
+        <div className="mx-auto flex max-w-2xl items-center gap-3 px-4 py-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 rounded-full text-slate-600"
+            onClick={() => navigate(-1)}
           >
-            <Home className="w-4 h-4" />
-            Inicio
-          </button>
-          <button
-            onClick={() => setActiveTab("all-content")}
-            className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-              activeTab === "all-content"
-                ? "border-orange-500 text-orange-600"
-                : "border-transparent text-gray-500 hover:text-gray-700"
-            }`}
-          >
-            <BookOpen className="w-4 h-4" />
-            Contenido
-          </button>
-          {courseData.modules.map((module) => (
-            <button
-              key={module.id}
-              onClick={() => setActiveTab(module.id)}
-              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-                activeTab === module.id
-                  ? "border-orange-500 text-orange-600"
-                  : "border-transparent text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              <FileText className="w-4 h-4" />
-              <span className="truncate max-w-32">{module.title}</span>
-            </button>
-          ))}
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div className="flex-1">
+            <p className="text-[13px] uppercase tracking-wider text-orange-500">Curso</p>
+            <h1 className="text-lg font-semibold text-slate-900">{courseDetail.title}</h1>
+          </div>
         </div>
-      </div>
+      </header>
 
-      {/* Tab Content */}
-      <div className="space-y-4">
-        {/* Overview Tab */}
-        {activeTab === "overview" && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {courseData.modules.map((module) => {
-              const moduleCompleted = module.contents.filter((c) =>
-                completedContents.includes(c.id)
-              ).length;
-              const moduleProgress = Math.round(
-                (moduleCompleted / module.contents.length) * 100
-              );
+      <main className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-6">
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-slate-900">Acerca del curso</h2>
+          <p className="text-sm leading-relaxed text-slate-600">{courseDetail.summary}</p>
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center gap-2">
+            <School className="h-4 w-4 text-orange-500" />
+            <h2 className="text-base font-semibold text-slate-900">
+              Materias del programa
+            </h2>
+          </div>
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {courseDetail.subjects.map((subject) => {
+              const isActive = subject.id === selectedSubjectId;
 
               return (
-                <Card
-                  key={module.id}
-                  className="cursor-pointer hover:shadow-sm transition-all duration-200 border-gray-100 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-600"
-                  onClick={() => setActiveTab(module.id)}
+                <button
+                  key={subject.id}
+                  type="button"
+                  onClick={() => {
+                    setSelectedSubjectId(subject.id);
+                    setExpandedModuleId(null);
+                  }}
+                  className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition-colors ${
+                    isActive
+                      ? "border-orange-500 bg-orange-500 text-white"
+                      : "border-slate-200 bg-white text-slate-600"
+                  }`}
                 >
-                  <CardContent className="p-4">
-                    <div className="flex items-center justify-between mb-3">
-                      <h3 className="font-semibold text-gray-900 dark:text-gray-100 truncate pr-2">
-                        {module.title}
-                      </h3>
-                      <Badge
-                        variant="outline"
-                        className="text-xs border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400"
-                      >
-                        {moduleCompleted}/{module.contents.length}
-                      </Badge>
-                    </div>
-                    <div className="h-2 w-full bg-gray-100 dark:bg-gray-700 rounded-full mb-3">
-                      <div
-                        className="h-2 bg-gradient-to-r from-orange-400 to-orange-500 rounded-full transition-all duration-300"
-                        style={{ width: `${moduleProgress}%` }}
-                      ></div>
-                    </div>
-                    <div className="grid grid-cols-2 gap-2 text-xs text-gray-500">
-                      <span>
-                        {
-                          module.contents.filter((c) => c.type === "VIDEO")
-                            .length
-                        }{" "}
-                        videos
-                      </span>
-                      <span>
-                        {module.contents.filter((c) => c.type === "PDF").length}{" "}
-                        PDFs
-                      </span>
-                    </div>
-                  </CardContent>
-                </Card>
+                  {subject.name}
+                </button>
               );
             })}
           </div>
-        )}
 
-        {/* All Content Tab */}
-        {activeTab === "all-content" && (
-          <div className="space-y-3">
-            {getAllContents().map((content) =>
-              renderContentItem(content, true)
-            )}
-          </div>
-        )}
-
-        {/* Individual Module Tabs */}
-        {courseData.modules.map(
-          (module) =>
-            activeTab === module.id && (
-              <div key={module.id} className="space-y-3">
-                <Card className="border-gray-100 dark:border-gray-800">
-                  <CardContent className="p-4">
-                    <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-2">
-                      {module.title}
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
-                      {module.description}
-                    </p>
-                    <div className="flex items-center gap-4">
-                      <span className="text-sm text-gray-500">
-                        {
-                          module.contents.filter((c) =>
-                            completedContents.includes(c.id)
-                          ).length
-                        }{" "}
-                        / {module.contents.length} completados
-                      </span>
-                      <div className="h-2 w-full bg-gray-100 dark:bg-gray-700 rounded-full">
-                        <div
-                          className="h-2 bg-gradient-to-r from-orange-400 to-orange-500 rounded-full transition-all duration-300"
-                          style={{
-                            width: `${Math.round(
-                              (module.contents.filter((c) =>
-                                completedContents.includes(c.id)
-                              ).length /
-                                module.contents.length) *
-                                100
-                            )}%`,
-                          }}
-                        ></div>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                <div className="space-y-3">
-                  {module.contents
-                    .sort((a, b) => a.order - b.order)
-                    .map((content) => renderContentItem(content))}
-                </div>
+          {selectedSubject && (
+            <div className="space-y-3">
+              <p className="text-sm text-slate-600">{selectedSubject.description}</p>
+              <div className="space-y-3">
+                {selectedSubject.modules.map((module) => renderModule(module))}
               </div>
-            )
-        )}
-      </div>
+            </div>
+          )}
+        </section>
 
-      {/* Mobile Fixed Bottom Tabs - minimalistas */}
-      <div className="fixed bottom-0 left-0 right-0 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-t border-gray-200 dark:border-gray-700 sm:hidden z-50">
-        <div className="flex items-center justify-around py-2">
-          <button
-            onClick={() => setActiveTab("overview")}
-            className={`flex flex-col items-center justify-center py-2 px-3 transition-colors ${
-              activeTab === "overview" ? "text-orange-500" : "text-gray-500"
-            }`}
-          >
-            <Home className="w-5 h-5 mb-1" />
-            <span className="text-xs">Inicio</span>
-          </button>
-
-          <button
-            onClick={() => setActiveTab("all-content")}
-            className={`flex flex-col items-center justify-center py-2 px-3 transition-colors ${
-              activeTab === "all-content" ? "text-orange-500" : "text-gray-500"
-            }`}
-          >
-            <BookOpen className="w-5 h-5 mb-1" />
-            <span className="text-xs">Todo</span>
-          </button>
-
-          {courseData.modules.map((module, index) => (
-            <button
-              key={module.id}
-              onClick={() => setActiveTab(module.id)}
-              className={`flex flex-col items-center justify-center py-2 px-3 transition-colors ${
-                activeTab === module.id ? "text-orange-500" : "text-gray-500"
-              }`}
-            >
-              <FileText className="w-5 h-5 mb-1" />
-              <span className="text-xs truncate max-w-12">
-                Tema {index + 1}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
+        <section className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+          <div className="flex items-start gap-3">
+            <BookOpen className="h-5 w-5 text-orange-500" />
+            <div className="space-y-1">
+              <h2 className="text-base font-semibold text-slate-900">
+                Cómo navegar el curso
+              </h2>
+              <p className="text-sm text-slate-600">
+                Elegí una materia para ver sus módulos y desplegá cada módulo para acceder a
+                los videos o PDFs correspondientes.
+              </p>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
   );
 };
 
-export default ModuleView;
+export default CourseDetailPage;

--- a/src/pages/Curso.tsx
+++ b/src/pages/Curso.tsx
@@ -275,7 +275,7 @@ const CourseDetailPage: React.FC = () => {
               Materias del programa
             </h2>
           </div>
-          <div className="flex gap-2 overflow-x-auto pb-1">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {courseDetail.subjects.map((subject) => {
               const isActive = subject.id === selectedSubjectId;
 
@@ -287,13 +287,27 @@ const CourseDetailPage: React.FC = () => {
                     setSelectedSubjectId(subject.id);
                     setExpandedModuleId(null);
                   }}
-                  className={`whitespace-nowrap rounded-full border px-4 py-2 text-sm transition-colors ${
+                  aria-pressed={isActive}
+                  className={`w-full rounded-2xl border px-4 py-3 text-left shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
                     isActive
-                      ? "border-orange-500 bg-orange-500 text-white"
-                      : "border-slate-200 bg-white text-slate-600"
+                      ? "border-orange-500 bg-orange-50 text-orange-700 ring-1 ring-orange-200"
+                      : "border-slate-200 bg-white text-slate-700 hover:border-orange-200 hover:bg-orange-50/60"
                   }`}
                 >
-                  {subject.name}
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="text-sm font-semibold leading-snug">{subject.name}</span>
+                    <Badge
+                      variant="outline"
+                      className={`border-0 text-[11px] font-medium uppercase tracking-wide ${
+                        isActive ? "bg-orange-500/10 text-orange-600" : "bg-slate-500/10 text-slate-600"
+                      }`}
+                    >
+                      {subject.modules.length} módulos
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600">
+                    {subject.description}
+                  </p>
                 </button>
               );
             })}


### PR DESCRIPTION
## Summary
- reestructuramos la vista de detalle del curso con enfoque mobile first y jerarquía clara curso → materias → módulos → ítems
- agregamos navegación simplificada por materias y módulos con tarjetas expandibles y badges informativos
- incorporamos iconografía diferenciada para videos y PDFs y estilos minimalistas para resaltar el contenido principal

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 --clearScreen false *(falla: falta la dependencia axios)*

------
https://chatgpt.com/codex/tasks/task_e_68db050ff79c8330825659581f100262