### PR TITLE
feat: ensure course page supports dark mode

### DIFF
--- a/src/pages/Curso.tsx
+++ b/src/pages/Curso.tsx
@@ -211,18 +211,18 @@ const CourseDetailPage: React.FC = () => {
     const isExpanded = expandedModuleId === module.id;
 
     return (
-      <Card key={module.id} className="border-slate-200 shadow-none">
+      <Card key={module.id} className="border-slate-200 shadow-none dark:border-slate-800 dark:bg-slate-900/60">
         <button
           type="button"
           onClick={() => handleModuleToggle(module.id)}
           className="w-full text-left"
         >
           <CardHeader className="space-y-1 px-4 py-3 sm:py-4">
-            <CardTitle className="text-base font-semibold text-slate-900">
+            <CardTitle className="text-base font-semibold text-slate-900 dark:text-slate-100">
               {module.name}
             </CardTitle>
-            <p className="text-sm text-slate-500">{module.description}</p>
-            <div className="flex items-center gap-2 text-xs text-slate-400">
+            <p className="text-sm text-slate-500 dark:text-slate-300">{module.description}</p>
+            <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
               <Video className="h-3.5 w-3.5" />
               <span>
                 {module.items.filter((item) => item.type === "VIDEO").length} videos
@@ -237,40 +237,40 @@ const CourseDetailPage: React.FC = () => {
         </button>
 
         {isExpanded && (
-          <CardContent className="space-y-3 border-t border-slate-100 bg-white px-4 py-3">
+          <CardContent className="space-y-3 border-t border-slate-100 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-900">
             {module.items.map((item) => {
               const isCompleted = completedItems.includes(item.id);
 
               return (
                 <div
                   key={item.id}
-                  className="flex items-start gap-3 rounded-lg border border-slate-100 bg-slate-50/70 px-3 py-3"
+                  className="flex items-start gap-3 rounded-lg border border-slate-100 bg-slate-50/70 px-3 py-3 dark:border-slate-800 dark:bg-slate-900/70"
                 >
                   <span
                     className={`mt-1 flex h-9 w-9 items-center justify-center rounded-full ${
                       item.type === "VIDEO"
-                        ? "bg-orange-100 text-orange-600"
-                        : "bg-slate-200 text-slate-600"
+                        ? "bg-orange-100 text-orange-600 dark:bg-orange-500/20 dark:text-orange-300"
+                        : "bg-slate-200 text-slate-600 dark:bg-slate-800 dark:text-slate-200"
                     }`}
                     aria-hidden="true"
                   >
                     {getItemIcon(item.type)}
                   </span>
                   <div className="flex-1 space-y-1">
-                    <p className="text-sm font-medium text-slate-900">{item.title}</p>
-                    <p className="text-xs text-slate-500">{item.description}</p>
+                    <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">{item.description}</p>
                     <div className="flex items-center gap-2">
                       <Badge
                         variant="outline"
                         className={`border-0 text-[11px] font-medium uppercase tracking-wide ${
                           item.type === "VIDEO"
-                            ? "bg-orange-500/10 text-orange-600"
-                            : "bg-slate-500/10 text-slate-600"
+                            ? "bg-orange-500/10 text-orange-600 dark:bg-orange-500/20 dark:text-orange-200"
+                            : "bg-slate-500/10 text-slate-600 dark:bg-slate-700/60 dark:text-slate-200"
                         }`}
                       >
                         {item.type}
                       </Badge>
-                      <span className="text-xs text-slate-400">{getItemBadge(item)}</span>
+                      <span className="text-xs text-slate-400 dark:text-slate-500">{getItemBadge(item)}</span>
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-2">
@@ -282,8 +282,8 @@ const CourseDetailPage: React.FC = () => {
                       onClick={() => toggleItemCompletion(item.id)}
                       className={`h-8 w-8 rounded-full border ${
                         isCompleted
-                          ? "border-green-200 bg-green-50 text-green-600"
-                          : "border-slate-200 text-slate-400 hover:border-green-200 hover:text-green-500"
+                          ? "border-green-200 bg-green-50 text-green-600 dark:border-green-700 dark:bg-green-900/40 dark:text-green-300"
+                          : "border-slate-200 text-slate-400 hover:border-green-200 hover:text-green-500 dark:border-slate-700 dark:text-slate-400 dark:hover:border-green-600/70 dark:hover:text-green-300"
                       }`}
                     >
                       <CheckCircle2 className="h-4 w-4" />
@@ -296,7 +296,7 @@ const CourseDetailPage: React.FC = () => {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-auto px-2 text-xs text-orange-600"
+                      className="h-auto px-2 text-xs text-orange-600 dark:text-orange-300"
                     >
                       {item.type === "VIDEO" ? "Ver" : "Descargar"}
                     </Button>
@@ -311,32 +311,32 @@ const CourseDetailPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-white">
-      <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/90 backdrop-blur">
+    <div className="min-h-screen bg-white dark:bg-slate-950">
+      <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
         <div className="mx-auto flex max-w-2xl items-center gap-3 px-4 py-3">
           <Button
             variant="ghost"
             size="icon"
-            className="h-9 w-9 rounded-full text-slate-600"
+            className="h-9 w-9 rounded-full text-slate-600 dark:text-slate-300"
             onClick={() => navigate(-1)}
           >
             <ArrowLeft className="h-5 w-5" />
           </Button>
           <div className="flex-1">
             <p className="text-[13px] uppercase tracking-wider text-orange-500">Curso</p>
-            <h1 className="text-lg font-semibold text-slate-900">{courseDetail.title}</h1>
+            <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{courseDetail.title}</h1>
           </div>
         </div>
       </header>
 
       <main className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-6">
-        <section className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+        <section className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-xs uppercase tracking-widest text-slate-400">
+              <p className="text-xs uppercase tracking-widest text-slate-400 dark:text-slate-400">
                 Progreso general
               </p>
-              <p className="text-sm font-semibold text-slate-900">
+              <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
                 {completedCount} de {totalItems} contenidos completados
               </p>
             </div>
@@ -350,7 +350,7 @@ const CourseDetailPage: React.FC = () => {
         <section className="space-y-4">
           <div className="flex items-center gap-2">
             <School className="h-4 w-4 text-orange-500" />
-            <h2 className="text-base font-semibold text-slate-900">
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
               Materias del programa
             </h2>
           </div>
@@ -367,24 +367,26 @@ const CourseDetailPage: React.FC = () => {
                     setExpandedModuleId(null);
                   }}
                   aria-pressed={isActive}
-                  className={`w-full rounded-2xl border px-4 py-3 text-left shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
+                  className={`w-full rounded-2xl border px-4 py-3 text-left shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950 ${
                     isActive
-                      ? "border-orange-500 bg-orange-50 text-orange-700 ring-1 ring-orange-200"
-                      : "border-slate-200 bg-white text-slate-700 hover:border-orange-200 hover:bg-orange-50/60"
+                      ? "border-orange-500 bg-orange-50 text-orange-700 ring-1 ring-orange-200 dark:border-orange-500 dark:bg-orange-500/10 dark:text-orange-200"
+                      : "border-slate-200 bg-white text-slate-700 hover:border-orange-200 hover:bg-orange-50/60 dark:border-slate-800 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:border-orange-300/60 dark:hover:bg-orange-500/5"
                   }`}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <span className="text-sm font-semibold leading-snug">{subject.name}</span>
+                    <span className="text-sm font-semibold leading-snug text-inherit">{subject.name}</span>
                     <Badge
                       variant="outline"
                       className={`border-0 text-[11px] font-medium uppercase tracking-wide ${
-                        isActive ? "bg-orange-500/10 text-orange-600" : "bg-slate-500/10 text-slate-600"
+                        isActive
+                          ? "bg-orange-500/10 text-orange-600 dark:bg-orange-500/20 dark:text-orange-200"
+                          : "bg-slate-500/10 text-slate-600 dark:bg-slate-700/60 dark:text-slate-200"
                       }`}
                     >
                       {subject.modules.length} módulos
                     </Badge>
                   </div>
-                  <p className="mt-1 text-xs leading-relaxed text-slate-600">
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">
                     {subject.description}
                   </p>
                 </button>
@@ -394,7 +396,7 @@ const CourseDetailPage: React.FC = () => {
 
           {selectedSubject && (
             <div className="space-y-3">
-              <p className="text-sm text-slate-600">{selectedSubject.description}</p>
+              <p className="text-sm text-slate-600 dark:text-slate-300">{selectedSubject.description}</p>
               <div className="space-y-3">
                 {selectedSubject.modules.map((module) => renderModule(module))}
               </div>
@@ -402,14 +404,14 @@ const CourseDetailPage: React.FC = () => {
           )}
         </section>
 
-        <section className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+        <section className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 dark:border-slate-800 dark:bg-slate-900/70">
           <div className="flex items-start gap-3">
             <BookOpen className="h-5 w-5 text-orange-500" />
             <div className="space-y-1">
-              <h2 className="text-base font-semibold text-slate-900">
+              <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
                 Cómo navegar el curso
               </h2>
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-slate-300">
                 Elegí una materia para ver sus módulos y desplegá cada módulo para acceder a
                 los videos o PDFs correspondientes.
               </p>


### PR DESCRIPTION
## Summary
- add dark theme backgrounds and text colors across the course detail layout
- adjust module cards, badges, and buttons to remain legible in dark mode

## Testing
- npm run build *(fails: missing axios dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68db0ca853fc83309171c797630450c5