### PR TITLE
Hide home carousel on mobile

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -69,7 +69,7 @@ const Index = () => {
   return (
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 space-y-6 sm:space-y-8">
       {/* Carrusel de banners */}
-      <div className="relative w-full overflow-hidden rounded-lg sm:rounded-xl shadow-lg mb-6 sm:mb-10">
+      <div className="hidden sm:block relative w-full overflow-hidden rounded-lg sm:rounded-xl shadow-lg mb-6 sm:mb-10">
         <div
           className="flex transition-transform duration-500 ease-in-out"
           style={{ transform: `translateX(-${currentBannerIndex * 100}%)` }}


### PR DESCRIPTION
## Summary
- hide the home page banner carousel on small screens while keeping it visible on desktop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcd5765248330aa00564def3a2be3