### PR TITLE
Fix search integration with current course structure

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -9,7 +9,7 @@ const BottomNavigation = () => {
 
   const navItems = [
     { icon: Home, label: "Inicio", path: "/" },
-    { icon: Play, label: "Clases", path: "/Curso" },
+    { icon: Play, label: "Clases", path: "/curso" },
     { icon: User, label: "Perfil", path: "/profile" },
   ];
 

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,0 +1,173 @@
+export type ContentType = "VIDEO" | "PDF" | "EVALUACION" | "EXTRA";
+
+export interface ModuleItem {
+  id: string;
+  title: string;
+  description: string;
+  type: ContentType;
+  duration?: string;
+  size?: string;
+  completed?: boolean;
+}
+
+export interface Module {
+  id: string;
+  name: string;
+  description: string;
+  items: ModuleItem[];
+}
+
+export interface Subject {
+  id: string;
+  name: string;
+  description: string;
+  modules: Module[];
+}
+
+export interface Course {
+  id: string;
+  title: string;
+  summary: string;
+  description: string;
+  image: string;
+  level: string;
+  status: "activo" | "inactivo";
+  subjects: Subject[];
+}
+
+export const courses: Course[] = [
+  {
+    id: "fitness-grupal",
+    title: "Instructorado de fitness grupal",
+    summary:
+      "Formación completa en fitness grupal con metodología actualizada y base científica aplicada.",
+    description:
+      "Formación completa en fitness grupal con metodología actualizada y base científica aplicada.",
+    image:
+      "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=400&h=250&fit=crop",
+    level: "Intermedio",
+    status: "activo",
+    subjects: [
+      {
+        id: "fundamentos",
+        name: "Fundamentos Anatómicos",
+        description:
+          "Comprendé cómo funciona el cuerpo y cómo impacta en la actividad física.",
+        modules: [
+          {
+            id: "fundamentos-anatomia",
+            name: "Anatomía y Fisiología",
+            description: "Base estructural del movimiento humano.",
+            items: [
+              {
+                id: "video-esqueleto",
+                title: "Anatomía del esqueleto humano",
+                description:
+                  "Recorrido visual por las principales estructuras óseas.",
+                type: "VIDEO",
+                duration: "18 min",
+                completed: true,
+              },
+              {
+                id: "pdf-articulaciones",
+                title: "Guía de articulaciones",
+                description: "Clasificación y cuidados básicos.",
+                type: "PDF",
+                size: "2.5 MB",
+                completed: true,
+              },
+              {
+                id: "video-musculos",
+                title: "Músculos en acción",
+                description: "Principales grupos musculares y funciones.",
+                type: "VIDEO",
+                duration: "22 min",
+                completed: false,
+              },
+            ],
+          },
+          {
+            id: "fundamentos-sistemas",
+            name: "Sistemas Energéticos",
+            description: "Cómo el cuerpo obtiene y usa la energía.",
+            items: [
+              {
+                id: "video-sistemas",
+                title: "Introducción a los sistemas energéticos",
+                description: "Fases y características clave.",
+                type: "VIDEO",
+                duration: "15 min",
+                completed: false,
+              },
+              {
+                id: "pdf-mapas",
+                title: "Mapas metabólicos",
+                description: "Material de apoyo descargable.",
+                type: "PDF",
+                size: "1.8 MB",
+                completed: false,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "planificacion",
+        name: "Planificación y Metodología",
+        description:
+          "Herramientas prácticas para diseñar clases seguras y dinámicas.",
+        modules: [
+          {
+            id: "planificacion-bases",
+            name: "Principios del Entrenamiento",
+            description: "Planificá sesiones con foco en resultados.",
+            items: [
+              {
+                id: "video-principios",
+                title: "Variables clave del entrenamiento",
+                description: "Frecuencia, intensidad y volumen explicados.",
+                type: "VIDEO",
+                duration: "20 min",
+                completed: false,
+              },
+              {
+                id: "pdf-hojas",
+                title: "Plantillas de planificación",
+                description: "Descargá y adaptá a tus clases.",
+                type: "PDF",
+                size: "800 KB",
+                completed: false,
+              },
+            ],
+          },
+          {
+            id: "planificacion-seguridad",
+            name: "Seguridad y Adaptaciones",
+            description: "Cuidados esenciales para distintos perfiles.",
+            items: [
+              {
+                id: "video-seguridad",
+                title: "Chequeos previos y adaptaciones",
+                description: "Checklist previo a cada clase.",
+                type: "VIDEO",
+                duration: "12 min",
+                completed: false,
+              },
+              {
+                id: "pdf-checklist",
+                title: "Checklist descargable",
+                description: "Formato imprimible para llevar a clase.",
+                type: "PDF",
+                size: "600 KB",
+                completed: false,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const getCourseById = (courseId: string) =>
+  courses.find((course) => course.id === courseId);

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -171,3 +171,25 @@ export const courses: Course[] = [
 
 export const getCourseById = (courseId: string) =>
   courses.find((course) => course.id === courseId);
+
+export const buildCourseUrl = (
+  courseId?: string,
+  subjectId?: string,
+  moduleId?: string
+) => {
+  const basePath = courseId ? `/curso/${courseId}` : "/curso";
+
+  const params = new URLSearchParams();
+
+  if (subjectId) {
+    params.set("materia", subjectId);
+  }
+
+  if (moduleId) {
+    params.set("modulo", moduleId);
+  }
+
+  const search = params.toString();
+
+  return search ? `${basePath}?${search}` : basePath;
+};

--- a/src/pages/Curso.tsx
+++ b/src/pages/Curso.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   ArrowLeft,
   BookOpen,
@@ -14,153 +14,72 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-
-const courseDetail = {
-  id: "fitness-grupal",
-  title: "Instructorado de fitness grupal",
-  summary:
-    "Formación completa en fitness grupal con metodología actualizada y base científica aplicada.",
-  subjects: [
-    {
-      id: "fundamentos",
-      name: "Fundamentos Anatómicos",
-      description:
-        "Comprendé cómo funciona el cuerpo y cómo impacta en la actividad física.",
-      modules: [
-        {
-          id: "fundamentos-anatomia",
-          name: "Anatomía y Fisiología",
-          description: "Base estructural del movimiento humano.",
-          items: [
-            {
-              id: "video-esqueleto",
-              title: "Anatomía del esqueleto humano",
-              description:
-                "Recorrido visual por las principales estructuras óseas.",
-              type: "VIDEO" as const,
-              duration: "18 min",
-              completed: true,
-            },
-            {
-              id: "pdf-articulaciones",
-              title: "Guía de articulaciones",
-              description: "Clasificación y cuidados básicos.",
-              type: "PDF" as const,
-              size: "2.5 MB",
-              completed: true,
-            },
-            {
-              id: "video-musculos",
-              title: "Músculos en acción",
-              description: "Principales grupos musculares y funciones.",
-              type: "VIDEO" as const,
-              duration: "22 min",
-              completed: false,
-            },
-          ],
-        },
-        {
-          id: "fundamentos-sistemas",
-          name: "Sistemas Energéticos",
-          description: "Cómo el cuerpo obtiene y usa la energía.",
-          items: [
-            {
-              id: "video-sistemas",
-              title: "Introducción a los sistemas energéticos",
-              description: "Fases y características clave.",
-              type: "VIDEO" as const,
-              duration: "15 min",
-              completed: false,
-            },
-            {
-              id: "pdf-mapas",
-              title: "Mapas metabólicos",
-              description: "Material de apoyo descargable.",
-              type: "PDF" as const,
-              size: "1.8 MB",
-              completed: false,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      id: "planificacion",
-      name: "Planificación y Metodología",
-      description:
-        "Herramientas prácticas para diseñar clases seguras y dinámicas.",
-      modules: [
-        {
-          id: "planificacion-bases",
-          name: "Principios del Entrenamiento",
-          description: "Planificá sesiones con foco en resultados.",
-          items: [
-            {
-              id: "video-principios",
-              title: "Variables clave del entrenamiento",
-              description: "Frecuencia, intensidad y volumen explicados.",
-              type: "VIDEO" as const,
-              duration: "20 min",
-              completed: false,
-            },
-            {
-              id: "pdf-hojas",
-              title: "Plantillas de planificación",
-              description: "Descargá y adaptá a tus clases.",
-              type: "PDF" as const,
-              size: "800 KB",
-              completed: false,
-            },
-          ],
-        },
-        {
-          id: "planificacion-seguridad",
-          name: "Seguridad y Adaptaciones",
-          description: "Cuidados esenciales para distintos perfiles.",
-          items: [
-            {
-              id: "video-seguridad",
-              title: "Chequeos previos y adaptaciones",
-              description: "Checklist previo a cada clase.",
-              type: "VIDEO" as const,
-              duration: "12 min",
-              completed: false,
-            },
-            {
-              id: "pdf-checklist",
-              title: "Checklist descargable",
-              description: "Formato imprimible para llevar a clase.",
-              type: "PDF" as const,
-              size: "600 KB",
-              completed: false,
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-type ModuleItem = (typeof courseDetail.subjects)[number]["modules"][number]["items"][number];
-
-type Subject = (typeof courseDetail.subjects)[number];
-
-type Module = Subject["modules"][number];
+import {
+  Course,
+  Module,
+  ModuleItem,
+  Subject,
+  courses,
+  getCourseById,
+} from "@/data/courses";
 
 const CourseDetailPage: React.FC = () => {
   const navigate = useNavigate();
-  const [selectedSubjectId, setSelectedSubjectId] = useState(courseDetail.subjects[0]?.id);
+  const { courseId } = useParams<{ courseId: string }>();
+  const [searchParams] = useSearchParams();
+
+  const courseDetail: Course | undefined = useMemo(() => {
+    if (courseId) {
+      return getCourseById(courseId) ?? courses[0];
+    }
+    return courses[0];
+  }, [courseId]);
+
+  const materiaParam = searchParams.get("materia");
+  const moduloParam = searchParams.get("modulo");
+
+  const [selectedSubjectId, setSelectedSubjectId] = useState<string | undefined>(
+    courseDetail?.subjects[0]?.id
+  );
   const [expandedModuleId, setExpandedModuleId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!courseDetail) return;
+
+    const subjectExists = materiaParam
+      ? courseDetail.subjects.some((subject) => subject.id === materiaParam)
+      : false;
+
+    const fallbackSubject = courseDetail.subjects[0]?.id;
+    setSelectedSubjectId(subjectExists ? (materiaParam as string) : fallbackSubject);
+
+    if (moduloParam) {
+      const moduleExists = courseDetail.subjects.some((subject) =>
+        subject.modules.some((module) => module.id === moduloParam)
+      );
+      setExpandedModuleId(moduleExists ? moduloParam : null);
+    } else {
+      setExpandedModuleId(null);
+    }
+  }, [courseDetail, materiaParam, moduloParam]);
+
   const initialCompletedItems = useMemo(() => {
+    if (!courseDetail) return [] as string[];
     return courseDetail.subjects.flatMap((subject) =>
       subject.modules.flatMap((module) =>
         module.items.filter((item) => item.completed).map((item) => item.id)
       )
     );
-  }, []);
+  }, [courseDetail]);
+
   const [completedItems, setCompletedItems] = useState<string[]>(initialCompletedItems);
 
+  useEffect(() => {
+    setCompletedItems(initialCompletedItems);
+  }, [initialCompletedItems]);
+
   const totalItems = useMemo(() => {
+    if (!courseDetail) return 0;
     return courseDetail.subjects.reduce((count, subject) => {
       return (
         count +
@@ -170,14 +89,15 @@ const CourseDetailPage: React.FC = () => {
         )
       );
     }, 0);
-  }, []);
+  }, [courseDetail]);
 
   const completedCount = completedItems.length;
   const progressPercentage = totalItems > 0 ? Math.round((completedCount / totalItems) * 100) : 0;
 
   const selectedSubject = useMemo<Subject | undefined>(() => {
+    if (!courseDetail) return undefined;
     return courseDetail.subjects.find((subject) => subject.id === selectedSubjectId);
-  }, [selectedSubjectId]);
+  }, [courseDetail, selectedSubjectId]);
 
   const handleModuleToggle = (moduleId: string) => {
     setExpandedModuleId((current) => (current === moduleId ? null : moduleId));
@@ -310,6 +230,21 @@ const CourseDetailPage: React.FC = () => {
     );
   };
 
+  if (!courseDetail) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-white dark:bg-slate-950">
+        <div className="text-center space-y-2">
+          <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Curso no encontrado
+          </p>
+          <Button variant="outline" onClick={() => navigate("/")}>
+            Volver al inicio
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-white dark:bg-slate-950">
       <header className="sticky top-0 z-10 border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
@@ -324,7 +259,12 @@ const CourseDetailPage: React.FC = () => {
           </Button>
           <div className="flex-1">
             <p className="text-[13px] uppercase tracking-wider text-orange-500">Curso</p>
-            <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{courseDetail.title}</h1>
+            <h1
+              className="text-lg font-semibold text-slate-900 dark:text-slate-100"
+              data-testid="course-title"
+            >
+              {courseDetail.title}
+            </h1>
           </div>
         </div>
       </header>
@@ -340,9 +280,7 @@ const CourseDetailPage: React.FC = () => {
                 {completedCount} de {totalItems} contenidos completados
               </p>
             </div>
-            <span className="text-sm font-semibold text-orange-600">
-              {progressPercentage}%
-            </span>
+            <span className="text-sm font-semibold text-orange-600">{progressPercentage}%</span>
           </div>
           <Progress value={progressPercentage} className="mt-3 h-2" />
         </section>
@@ -357,6 +295,18 @@ const CourseDetailPage: React.FC = () => {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {courseDetail.subjects.map((subject) => {
               const isActive = subject.id === selectedSubjectId;
+
+              const completedInSubject = subject.modules.reduce(
+                (acc, module) =>
+                  acc +
+                  module.items.filter((item) => completedItems.includes(item.id))
+                    .length,
+                0
+              );
+              const totalInSubject = subject.modules.reduce(
+                (acc, module) => acc + module.items.length,
+                0
+              );
 
               return (
                 <button
@@ -383,7 +333,7 @@ const CourseDetailPage: React.FC = () => {
                           : "bg-slate-500/10 text-slate-600 dark:bg-slate-700/60 dark:text-slate-200"
                       }`}
                     >
-                      {subject.modules.length} módulos
+                      {completedInSubject}/{totalInSubject} contenidos
                     </Badge>
                   </div>
                   <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">
@@ -412,8 +362,7 @@ const CourseDetailPage: React.FC = () => {
                 Cómo navegar el curso
               </h2>
               <p className="text-sm text-slate-600 dark:text-slate-300">
-                Elegí una materia para ver sus módulos y desplegá cada módulo para acceder a
-                los videos o PDFs correspondientes.
+                Elegí una materia para ver sus módulos y desplegá cada módulo para acceder a los videos o PDFs correspondientes.
               </p>
             </div>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { ChevronRight } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { useNavigate } from "react-router-dom";
-import { courses } from "@/data/courses";
+import { buildCourseUrl, courses } from "@/data/courses";
 
 const Index = () => {
   const navigate = useNavigate();
@@ -122,7 +122,7 @@ const Index = () => {
               <Card
                 key={course.id}
                 className="bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-300 overflow-hidden cursor-pointer"
-                onClick={() => navigate(`/curso/${course.id}`)}
+                onClick={() => navigate(buildCourseUrl(course.id))}
               >
                 <CardContent className="p-0 flex flex-col sm:flex-row">
                   {/* Imagen del curso */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { ChevronRight } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { useNavigate } from "react-router-dom";
+import { courses } from "@/data/courses";
 
 const Index = () => {
   const navigate = useNavigate();
@@ -27,44 +28,40 @@ const Index = () => {
     return () => clearInterval(interval);
   }, []);
 
-  // Mock data de cursos como INEE
-  const courses = [
-    {
-      id: "fitness-grupal",
-      title: "Instructorado de fitness grupal",
-      description:
-        "Formación completa en fitness grupal con metodología actualizada y base científica aplicada.",
-      image:
-        "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=400&h=250&fit=crop",
-      level: "Intermedio",
-      modules: [
-        {
-          id: "mod1",
-          contents: [
-            { completed: true },
-            { completed: true },
-            { completed: false },
-          ],
+  const coursesWithProgress = useMemo(() => {
+    return courses.map((course) => {
+      const { totalItems, completedItems } = course.subjects.reduce(
+        (acc, subject) => {
+          subject.modules.forEach((module) => {
+            acc.totalItems += module.items.length;
+            acc.completedItems += module.items.filter(
+              (item) => item.completed
+            ).length;
+          });
+          return acc;
         },
-        { id: "mod2", contents: [{ completed: false }, { completed: false }] },
-      ],
-    },
-  ];
+        { totalItems: 0, completedItems: 0 }
+      );
 
-  const getActualProgress = (course) => {
-    const totalContents = course.modules.reduce(
-      (acc, module) => acc + module.contents.length,
-      0
-    );
-    const completedContents = course.modules.reduce(
-      (acc, module) =>
-        acc + module.contents.filter((content) => content.completed).length,
-      0
-    );
-    return totalContents > 0
-      ? Math.round((completedContents / totalContents) * 100)
-      : 0;
-  };
+      const progress =
+        totalItems > 0
+          ? Math.round((completedItems / totalItems) * 100)
+          : 0;
+
+      const totalModules = course.subjects.reduce(
+        (acc, subject) => acc + subject.modules.length,
+        0
+      );
+
+      return {
+        ...course,
+        totalItems,
+        completedItems,
+        progress,
+        totalModules,
+      };
+    });
+  }, []);
 
   return (
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 space-y-6 sm:space-y-8">
@@ -120,12 +117,7 @@ const Index = () => {
           Mis formaciones
         </h2>
         <div className="grid grid-cols-1 gap-4">
-          {courses.map((course) => {
-            const actualProgress = getActualProgress(course);
-            const totalContents = course.modules.reduce(
-              (acc, module) => acc + module.contents.length,
-              0
-            );
+          {coursesWithProgress.map((course) => {
             return (
               <Card
                 key={course.id}
@@ -148,7 +140,7 @@ const Index = () => {
                         {course.title}
                       </h3>
                       <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2 break-words">
-                        {course.description}
+                        {course.summary}
                       </p>
                     </div>
                     <div>
@@ -158,10 +150,10 @@ const Index = () => {
                             {course.level}
                           </span>
                           <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                            {course.modules.length} módulos
+                            {course.subjects.length} materias
                           </span>
                           <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                            {totalContents} elementos
+                            {course.totalModules} módulos · {course.totalItems} contenidos
                           </span>
                         </div>
                         <ChevronRight className="w-4 h-4 sm:w-5 sm:h-5 text-gray-400 dark:text-gray-500 self-end sm:self-center" />
@@ -171,11 +163,11 @@ const Index = () => {
                         <div className="h-2 w-full bg-gray-100 dark:bg-gray-700 rounded-full">
                           <div
                             className="h-2 bg-gradient-to-r from-orange-400 to-orange-500 rounded-full transition-all duration-300 shadow-sm"
-                            style={{ width: `${actualProgress}%` }}
+                            style={{ width: `${course.progress}%` }}
                           ></div>
                         </div>
                         <span className="text-xs text-orange-600 dark:text-orange-400 font-medium min-w-[2.5rem] text-right">
-                          {actualProgress}%
+                          {course.progress}%
                         </span>
                       </div>
                     </div>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,93 +1,179 @@
-
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Search as SearchIcon, Play, BookOpen, Filter } from "lucide-react";
+import {
+  Search as SearchIcon,
+  Play,
+  BookOpen,
+  Filter,
+  School,
+} from "lucide-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { courses } from "@/data/courses";
+
+type FilterType = "all" | "course" | "materia" | "modulo";
+type SearchResultType = Exclude<FilterType, "all">;
+
+interface SearchResult {
+  id: string;
+  type: SearchResultType;
+  title: string;
+  description: string;
+  path: string;
+  courseTitle?: string;
+  subjectName?: string;
+  meta: string[];
+}
+
+const TYPE_CONFIG = {
+  course: {
+    label: "Curso",
+    icon: <School className="w-6 h-6" />,
+    iconClass: "bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400",
+    badgeClass:
+      "border-blue-200 text-blue-700 dark:border-blue-700 dark:text-blue-300",
+  },
+  materia: {
+    label: "Materia",
+    icon: <BookOpen className="w-6 h-6" />,
+    iconClass: "bg-purple-100 dark:bg-purple-900 text-purple-600 dark:text-purple-400",
+    badgeClass:
+      "border-purple-200 text-purple-700 dark:border-purple-700 dark:text-purple-300",
+  },
+  modulo: {
+    label: "Módulo",
+    icon: <Play className="w-6 h-6" />,
+    iconClass:
+      "bg-orange-100 dark:bg-orange-900 text-orange-600 dark:text-orange-300",
+    badgeClass:
+      "border-orange-200 text-orange-700 dark:border-orange-700 dark:text-orange-300",
+  },
+} as const satisfies Record<SearchResultType, {
+  label: string;
+  icon: JSX.Element;
+  iconClass: string;
+  badgeClass: string;
+}>;
+
+const filterOptions: { value: FilterType; label: string }[] = [
+  { value: "all", label: "Todo" },
+  { value: "course", label: "Cursos" },
+  { value: "materia", label: "Materias" },
+  { value: "modulo", label: "Módulos" },
+];
 
 const Search = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [query, setQuery] = useState(searchParams.get('q') || '');
-  const [filter, setFilter] = useState<'all' | 'classes' | 'theory'>('all');
+  const [query, setQuery] = useState(searchParams.get("q") || "");
+  const [filter, setFilter] = useState<FilterType>("all");
 
-  // Mock data - en una app real esto vendría de una API o base de datos
-  const searchData = [
-    {
-      id: 'clase-1-1',
-      type: 'class',
-      title: 'Introducción al Fitness Grupal',
-      description: 'Fundamentos básicos del entrenamiento grupal',
-      module: 'Módulo 1',
-      duration: '35 min',
-      path: '/classes/modulo-1/clase-1-1'
-    },
-    {
-      id: 'clase-2-1',
-      type: 'class', 
-      title: 'Entrenamiento de Fuerza',
-      description: 'Técnicas y metodología para el desarrollo de la fuerza',
-      module: 'Módulo 2',
-      duration: '48 min',
-      path: '/classes/modulo-2/clase-2-1'
-    },
-    {
-      id: 'unidad-1',
-      type: 'theory',
-      title: 'Anatomía y Fisiología del Ejercicio',
-      description: 'Sistema muscular, cardiovascular y metabolismo energético',
-      readTime: '25 min',
-      path: '/theory/unidad-1'
-    },
-    {
-      id: 'unidad-3',
-      type: 'theory',
-      title: 'Biomecánica del Movimiento',
-      description: 'Análisis técnico de ejercicios y planos de movimiento',
-      readTime: '35 min',
-      path: '/theory/unidad-3'
-    },
-    {
-      id: 'clase-3-1',
-      type: 'class',
-      title: 'HIIT y Entrenamiento Funcional',
-      description: 'Técnicas de alta intensidad y ejercicios funcionales',
-      module: 'Módulo 3',
-      duration: '45 min',
-      path: '/classes/modulo-3/clase-3-1'
-    },
-    {
-      id: 'unidad-4',
-      type: 'theory',
-      title: 'Nutrición Deportiva',
-      description: 'Macronutrientes, hidratación y suplementación',
-      readTime: '28 min',
-      path: '/theory/unidad-4'
-    }
-  ];
+  useEffect(() => {
+    setQuery(searchParams.get("q") || "");
+  }, [searchParams]);
+
+  const searchIndex = useMemo<SearchResult[]>(() => {
+    return courses.flatMap((course) => {
+      const totalModules = course.subjects.reduce(
+        (acc, subject) => acc + subject.modules.length,
+        0
+      );
+      const totalItems = course.subjects.reduce(
+        (acc, subject) =>
+          acc + subject.modules.reduce((count, module) => count + module.items.length, 0),
+        0
+      );
+
+      const courseResult: SearchResult = {
+        id: `course-${course.id}`,
+        type: "course",
+        title: course.title,
+        description: course.summary,
+        path: `/curso/${course.id}`,
+        meta: [
+          `${course.subjects.length} materias`,
+          `${totalModules} módulos`,
+          `${totalItems} contenidos`,
+        ],
+      };
+
+      const subjectResults: SearchResult[] = course.subjects.flatMap((subject) => {
+        const subjectModuleCount = subject.modules.length;
+        const subjectItemCount = subject.modules.reduce(
+          (acc, module) => acc + module.items.length,
+          0
+        );
+
+        const baseSubject: SearchResult = {
+          id: `materia-${course.id}-${subject.id}`,
+          type: "materia",
+          title: subject.name,
+          description: subject.description,
+          courseTitle: course.title,
+          path: `/curso/${course.id}?materia=${subject.id}`,
+          meta: [
+            `${subjectModuleCount} módulos`,
+            `${subjectItemCount} contenidos`,
+          ],
+        };
+
+        const moduleResults: SearchResult[] = subject.modules.map((module) => {
+          const moduleItemCount = module.items.length;
+          const completedCount = module.items.filter((item) => item.completed).length;
+
+          const moduleMeta = [
+            `${moduleItemCount} contenidos`,
+            `${completedCount} completados`,
+          ];
+
+          return {
+            id: `modulo-${course.id}-${subject.id}-${module.id}`,
+            type: "modulo",
+            title: module.name,
+            description: module.description,
+            courseTitle: course.title,
+            subjectName: subject.name,
+            path: `/curso/${course.id}?materia=${subject.id}&modulo=${module.id}`,
+            meta: moduleMeta,
+          };
+        });
+
+        return [baseSubject, ...moduleResults];
+      });
+
+      return [courseResult, ...subjectResults];
+    });
+  }, []);
 
   const filteredResults = useMemo(() => {
-    let results = searchData;
+    let results = searchIndex;
 
-    // Aplicar filtro por tipo
-    if (filter !== 'all') {
-      results = results.filter(item => item.type === filter);
+    if (filter !== "all") {
+      results = results.filter((item) => item.type === filter);
     }
 
-    // Aplicar búsqueda por texto
     if (query.trim()) {
       const searchTerm = query.toLowerCase();
-      results = results.filter(item => 
-        item.title.toLowerCase().includes(searchTerm) ||
-        item.description.toLowerCase().includes(searchTerm) ||
-        (item.type === 'class' && item.module?.toLowerCase().includes(searchTerm))
-      );
+      results = results.filter((item) => {
+        const haystack = [
+          item.title,
+          item.description,
+          item.courseTitle,
+          item.subjectName,
+          ...item.meta,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+
+        return haystack.includes(searchTerm);
+      });
     }
 
     return results;
-  }, [query, filter]);
+  }, [filter, query, searchIndex]);
 
   return (
     <div className="container mx-auto px-4 py-6 space-y-6">
@@ -96,115 +182,96 @@ const Search = () => {
           Buscar Contenido
         </h1>
         <p className="text-gray-600 dark:text-gray-300">
-          Encuentra clases y material teórico
+          Encontrá cursos, materias y módulos del campus
         </p>
       </div>
 
-      {/* Barra de búsqueda */}
       <div className="relative">
         <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
         <Input
           type="search"
-          placeholder="Buscar por título, descripción o módulo..."
+          placeholder="Buscar por título, materia, módulo o descripción..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="pl-12 h-12 text-lg bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
         />
       </div>
 
-      {/* Filtros */}
       <div className="flex items-center space-x-2 overflow-x-auto pb-2">
         <Filter className="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
-        <Button
-          variant={filter === 'all' ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => setFilter('all')}
-          className="whitespace-nowrap"
-        >
-          Todo
-        </Button>
-        <Button
-          variant={filter === 'classes' ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => setFilter('classes')}
-          className="whitespace-nowrap"
-        >
-          Clases
-        </Button>
-        <Button
-          variant={filter === 'theory' ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => setFilter('theory')}
-          className="whitespace-nowrap"
-        >
-          Teoría
-        </Button>
+        {filterOptions.map((option) => (
+          <Button
+            key={option.value}
+            variant={filter === option.value ? "default" : "outline"}
+            size="sm"
+            onClick={() => setFilter(option.value)}
+            className="whitespace-nowrap"
+          >
+            {option.label}
+          </Button>
+        ))}
       </div>
 
-      {/* Resultados */}
       <div className="space-y-3">
         {filteredResults.length > 0 ? (
           <>
             <p className="text-sm text-gray-500 dark:text-gray-400">
-              {filteredResults.length} resultado{filteredResults.length !== 1 ? 's' : ''} encontrado{filteredResults.length !== 1 ? 's' : ''}
+              {filteredResults.length} resultado{filteredResults.length !== 1 ? "s" : ""} encontrado{filteredResults.length !== 1 ? "s" : ""}
             </p>
-            {filteredResults.map((item) => (
-              <Card 
-                key={item.id}
-                className="cursor-pointer hover:shadow-md transition-all duration-200 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
-                onClick={() => navigate(item.path)}
-              >
-                <CardContent className="p-4">
-                  <div className="flex items-start space-x-4">
-                    <div className={`w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0 ${
-                      item.type === 'class'
-                        ? 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400'
-                        : 'bg-purple-100 dark:bg-purple-900 text-purple-600 dark:text-purple-400'
-                    }`}>
-                      {item.type === 'class' ? (
-                        <Play className="w-6 h-6" />
-                      ) : (
-                        <BookOpen className="w-6 h-6" />
-                      )}
-                    </div>
-                    
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between">
-                        <h3 className="font-medium text-gray-900 dark:text-gray-100 line-clamp-2">
-                          {item.title}
-                        </h3>
-                        <Badge 
-                          variant="outline"
-                          className={`ml-2 ${
-                            item.type === 'class'
-                              ? 'border-blue-200 text-blue-700 dark:border-blue-700 dark:text-blue-300'
-                              : 'border-purple-200 text-purple-700 dark:border-purple-700 dark:text-purple-300'
-                          }`}
-                        >
-                          {item.type === 'class' ? 'Clase' : 'Teoría'}
-                        </Badge>
+            {filteredResults.map((item) => {
+              const config = TYPE_CONFIG[item.type];
+              const infoLine = [
+                item.type !== "course" ? item.courseTitle : null,
+                item.type === "modulo" ? item.subjectName : null,
+                ...item.meta,
+              ].filter(Boolean) as string[];
+
+              return (
+                <Card
+                  key={item.id}
+                  className="cursor-pointer hover:shadow-md transition-all duration-200 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700"
+                  onClick={() => navigate(item.path)}
+                >
+                  <CardContent className="p-4">
+                    <div className="flex items-start space-x-4">
+                      <div
+                        className={`w-12 h-12 rounded-lg flex items-center justify-center flex-shrink-0 ${config.iconClass}`}
+                      >
+                        {config.icon}
                       </div>
-                      
-                      <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2">
-                        {item.description}
-                      </p>
-                      
-                      <div className="flex items-center space-x-4 mt-2 text-sm text-gray-500 dark:text-gray-400">
-                        {item.type === 'class' ? (
-                          <>
-                            <span>{item.module}</span>
-                            <span>•</span>
-                            <span>{item.duration}</span>
-                          </>
-                        ) : (
-                          <span>Tiempo de lectura: {item.readTime}</span>
-                        )}
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2">
+                          <h3 className="font-medium text-gray-900 dark:text-gray-100 line-clamp-2">
+                            {item.title}
+                          </h3>
+                          <Badge variant="outline" className={`ml-2 ${config.badgeClass}`}>
+                            {config.label}
+                          </Badge>
+                        </div>
+
+                        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1 line-clamp-2">
+                          {item.description}
+                        </p>
+
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-2 text-sm text-gray-500 dark:text-gray-400">
+                          {infoLine.map((info, index) => (
+                            <span key={`${item.id}-meta-${index}`} className="flex items-center gap-2">
+                              {index > 0 && (
+                                <span className="text-gray-300 dark:text-gray-600" aria-hidden="true">
+                                  •
+                                </span>
+                              )}
+                              <span>{info}</span>
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
+                  </CardContent>
+                </Card>
+              );
+            })}
           </>
         ) : (
           <div className="text-center py-12">

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -11,7 +11,7 @@ import {
   School,
 } from "lucide-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { courses } from "@/data/courses";
+import { buildCourseUrl, courses } from "@/data/courses";
 
 type FilterType = "all" | "course" | "materia" | "modulo";
 type SearchResultType = Exclude<FilterType, "all">;
@@ -91,7 +91,7 @@ const Search = () => {
         type: "course",
         title: course.title,
         description: course.summary,
-        path: `/curso/${course.id}`,
+        path: buildCourseUrl(course.id),
         meta: [
           `${course.subjects.length} materias`,
           `${totalModules} módulos`,
@@ -112,7 +112,7 @@ const Search = () => {
           title: subject.name,
           description: subject.description,
           courseTitle: course.title,
-          path: `/curso/${course.id}?materia=${subject.id}`,
+          path: buildCourseUrl(course.id, subject.id),
           meta: [
             `${subjectModuleCount} módulos`,
             `${subjectItemCount} contenidos`,
@@ -135,7 +135,7 @@ const Search = () => {
             description: module.description,
             courseTitle: course.title,
             subjectName: subject.name,
-            path: `/curso/${course.id}?materia=${subject.id}&modulo=${module.id}`,
+            path: buildCourseUrl(course.id, subject.id, module.id),
             meta: moduleMeta,
           };
         });


### PR DESCRIPTION
## Summary
- add a shared course data module that models courses, materias, and módulos
- refactor the course detail and dashboard pages to consume the shared course data and open specific materias via URL params
- rebuild the search page to index courses, materias, and módulos with new filters and metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbcbbf0a988330a747b480ec73a6b0