### PR TITLE
Replace mobile profile nav with search

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,6 +1,6 @@
 
 import { useCallback, useEffect, useState } from "react";
-import { Home, Play, User } from "lucide-react";
+import { Home, Play, Search } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 
@@ -148,7 +148,13 @@ const BottomNavigation = () => {
       activePath: "/curso",
       ariaLabel: continueAriaLabel,
     },
-    { icon: User, label: "Perfil", path: "/profile", activePath: "/profile" },
+    {
+      icon: Search,
+      label: "Buscar",
+      path: "/search",
+      activePath: "/search",
+      ariaLabel: "Buscar clases o teoría",
+    },
   ];
 
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -84,15 +84,6 @@ const Header = () => {
 
           <div className="flex items-center space-x-2">
             <ThemeToggle />
-            <Button
-              variant="ghost"
-              size="icon"
-              className="md:hidden"
-              onClick={() => navigate("/search")}
-            >
-              <Search className="w-5 h-5" />
-            </Button>
-
             {user ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
- replace the mobile bottom navigation profile button with a search shortcut that opens the search page
- remove the redundant navbar search icon on mobile so the search entry is only shown in the bottom menu

## Testing
- npm run build *(fails: Rollup failed to resolve import "axios" from src/services/authService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd15d5dcc8330a814a791fe34efa3