### PR TITLE
Fix-EPEFI-132-CONTADOR-MODULOS-LOGICA-UI

### DIFF
--- a/src/pages/Curso.tsx
+++ b/src/pages/Curso.tsx
@@ -41,6 +41,7 @@ import VideoModal from "@/components/video-modal";
 import CourseExamSection from "@/components/CourseExamSection";
 import { getMissingModuleIds } from "@/lib/courseModules";
 import { getModulesForMateria } from "@/lib/courseModules";
+import { isModuleFullyCompleted } from "@/lib/courseProgress";
 import { useAuth } from "@/contexts/AuthContext";
 
 const CourseDetailPage = () => {
@@ -920,6 +921,9 @@ const CourseDetailPage = () => {
                     const materiasModulos = getModulesForMateria(materia, modulos);
                     const missingModuleIds = getMissingModuleIds(materia, modulos);
                     const totalEnMateria = materia.modulos?.length ?? materiasModulos.length;
+                    const modulosCompletados = materiasModulos.filter((modulo) =>
+                      isModuleFullyCompleted(modulo, progress)
+                    ).length;
 
                   return (
                     <AccordionItem
@@ -938,7 +942,7 @@ const CourseDetailPage = () => {
                                   {materia.nombre}
                                 </span>
                                 <p className="text-xs sm:text-sm text-slate-500 dark:text-slate-400 mt-1 leading-relaxed">
-                                  {materiasModulos.length} de {totalEnMateria} módulo
+                                  {modulosCompletados} de {totalEnMateria} módulo
                                   {totalEnMateria !== 1 ? "s" : ""}
                                 </p>
                               </div>


### PR DESCRIPTION
Ticket: <!-- ID del ticket en JIRA-->

## Qué y por qué

El contador de módulos por materia mostraba el total cargado en lugar de los completados; ahora usa isModuleFullyCompleted, igual que el check verde de cada módulo.

## Qué puede romper

Módulos vacíos cuentan como completados.

## Capturas

<img width="1140" height="471" alt="image" src="https://github.com/user-attachments/assets/1d317839-dea8-43aa-9b43-7472f7fa769b" />
